### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -1,4 +1,6 @@
 name: Install Python Dependencies and Check for Conflicts
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Elias2660/Unified-bee-Runner/security/code-scanning/1](https://github.com/Elias2660/Unified-bee-Runner/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow only checks out the repository, sets up Python, installs dependencies, and runs tests, it likely only needs `contents: read` permission. This ensures that the workflow has the least privilege necessary to perform its tasks.

The `permissions` block should be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
